### PR TITLE
Add Solana wallet context and document summary

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,9 @@
+import { useState } from "react";
 import { Route, Routes } from "react-router-dom";
 
 // Main application layout stitches together uploads, hash lookup, and Solana status.
-import { FileUpload } from "@/components/file-upload";
+import { FileUpload, type FileUploadDocumentChange } from "@/components/file-upload";
+import { DocumentSummaryCard } from "@/components/document-summary-card";
 import { SolanaTransactionPanel } from "@/components/solana-transaction-panel";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -9,13 +11,15 @@ import { Label } from "@/components/ui/label";
 import { DocumentDetailPage } from "@/pages/document-detail-page";
 
 function HomePage() {
+  const [latestDocument, setLatestDocument] = useState<FileUploadDocumentChange | null>(null);
+
   return (
     <div className="flex min-h-screen flex-col bg-muted">
       <main className="flex flex-1 items-center justify-center px-4 py-12">
         <div className="grid w-full max-w-5xl gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,420px)]">
           <div className="space-y-6">
             {/* File uploader remains the primary document ingestion path. */}
-            <FileUpload />
+            <FileUpload onDocumentChange={setLatestDocument} />
             {/* Divider offers a visual cue before the hash lookup path. */}
             <div className="flex items-center gap-4 text-xs font-semibold uppercase text-muted-foreground">
               <div className="h-px flex-1 bg-muted-foreground/40" aria-hidden="true" />
@@ -40,7 +44,10 @@ function HomePage() {
               </div>
             </div>
           </div>
-          <SolanaTransactionPanel />
+          <div className="space-y-6">
+            <SolanaTransactionPanel />
+            <DocumentSummaryCard document={latestDocument} />
+          </div>
         </div>
       </main>
     </div>

--- a/src/components/document-summary-card.tsx
+++ b/src/components/document-summary-card.tsx
@@ -1,0 +1,57 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { FileUploadDocumentChange } from "@/components/file-upload";
+
+interface DocumentSummaryCardProps {
+  document: FileUploadDocumentChange | null;
+}
+
+const formatTimestamp = (value: string | null | undefined) => {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleString();
+};
+
+const formatChecksum = (value: string | null | undefined) => value ?? "—";
+
+const formatTransactionHash = (document: FileUploadDocumentChange | null) => {
+  if (!document) return "—";
+
+  if (document.transactionStatus === "pending") {
+    return "Awaiting signature";
+  }
+
+  if (document.transactionStatus === "cancelled") {
+    return "Signature cancelled";
+  }
+
+  if (document.transactionStatus === "error") {
+    return document.error ?? "Signing failed";
+  }
+
+  return document.transactionHash ?? "—";
+};
+
+export function DocumentSummaryCard({ document }: DocumentSummaryCardProps) {
+  return (
+    <Card className="w-full max-w-xl">
+      <CardHeader>
+        <CardTitle className="text-lg font-semibold">My Document</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        <div>
+          <p className="text-xs font-medium uppercase text-muted-foreground">Timestamp</p>
+          <p className="mt-1 font-mono text-foreground">{formatTimestamp(document?.timestamp)}</p>
+        </div>
+        <div>
+          <p className="text-xs font-medium uppercase text-muted-foreground">Checksum</p>
+          <p className="mt-1 break-all font-mono text-foreground">{formatChecksum(document?.checksum)}</p>
+        </div>
+        <div>
+          <p className="text-xs font-medium uppercase text-muted-foreground">Transaction Hash</p>
+          <p className="mt-1 break-all font-mono text-foreground">{formatTransactionHash(document)}</p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/solana-transaction-panel.tsx
+++ b/src/components/solana-transaction-panel.tsx
@@ -1,168 +1,47 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { CheckCircle2, ExternalLink, Loader2, SendHorizonal, Wallet } from "lucide-react";
+import { useCallback, useMemo } from "react";
+import { Loader2, Wallet } from "lucide-react";
 
-import type { Address } from "gill";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import type { SolanaWindowProvider } from "@/types/solana";
-import { getSolanaClient } from "@/lib/solana/client";
-import { sendMemoTransaction } from "@/lib/solana/transactions";
-
-type TransactionState = "idle" | "sending" | "sent";
-
-const DEFAULT_MEMO = "Hello from the Gill SDK";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useSolanaWallet } from "@/lib/solana/wallet-context";
 
 export function SolanaTransactionPanel() {
-  const [memo, setMemo] = useState(DEFAULT_MEMO);
-  const [provider, setProvider] = useState<SolanaWindowProvider | null>(null);
-  const [address, setAddress] = useState<string | null>(null);
-  const [signature, setSignature] = useState<string | null>(null);
-  const [explorerUrl, setExplorerUrl] = useState<string | null>(null);
-  const [connectError, setConnectError] = useState<string | null>(null);
-  const [transactionError, setTransactionError] = useState<string | null>(null);
-  const [transactionState, setTransactionState] = useState<TransactionState>("idle");
-  const [isConnecting, setIsConnecting] = useState(false);
+  const { address, connect, disconnect, isConnecting, connectError } = useSolanaWallet();
 
-  const client = useMemo(() => getSolanaClient(), []);
+  const isConnected = useMemo(() => Boolean(address), [address]);
 
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    setProvider(window.solana ?? null);
-  }, []);
-
-  const handleConnect = useCallback(async () => {
-    setConnectError(null);
-    if (!provider) {
-      setConnectError("No Solana wallet detected. Install Phantom or another Wallet Standard provider.");
-      return;
+  const handleClick = useCallback(() => {
+    if (isConnected) {
+      return disconnect();
     }
 
-    setIsConnecting(true);
-    try {
-      const result = await provider.connect({ onlyIfTrusted: false });
-      setAddress(result.publicKey.toBase58());
-      setSignature(null);
-      setExplorerUrl(null);
-    } catch (error) {
-      if (error instanceof Error) {
-        setConnectError(error.message);
-      } else {
-        setConnectError("Unable to connect to the Solana wallet.");
-      }
-    } finally {
-      setIsConnecting(false);
-    }
-  }, [provider]);
-
-  const handleSendTransaction = useCallback(async () => {
-    if (!provider || !provider.signTransaction || !address) {
-      setTransactionError(
-        "A connected Solana wallet that supports transaction signing is required to submit transactions.",
-      );
-      return;
-    }
-
-    setTransactionError(null);
-    setTransactionState("sending");
-    try {
-      const { explorerUrl: url, signature: txSignature } = await sendMemoTransaction({
-        client,
-        wallet: {
-          address: address as Address<string>,
-          signTransaction: provider.signTransaction.bind(provider),
-        },
-        memo,
-      });
-
-      setSignature(txSignature);
-      setExplorerUrl(url);
-      setTransactionState("sent");
-    } catch (error) {
-      if (error instanceof Error) {
-        setTransactionError(error.message);
-      } else {
-        setTransactionError("Failed to send the Solana transaction.");
-      }
-      setTransactionState("idle");
-    }
-  }, [address, client, memo, provider]);
-
-  const isConnected = !!address;
-  const isSendDisabled = transactionState === "sending" || !isConnected;
+    return connect();
+  }, [connect, disconnect, isConnected]);
 
   return (
     <Card className="w-full max-w-xl">
       <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <SendHorizonal className="h-5 w-5" /> Gill SDK Solana Transaction
-        </CardTitle>
-        <CardDescription>
-          Use the Gill SDK to craft and submit a memo transaction on Solana directly from the browser.
-        </CardDescription>
+        <CardTitle className="text-lg font-semibold">Gill SDK Wallet</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="space-y-2">
-          <label className="text-sm font-medium" htmlFor="solana-memo">
-            Memo message
-          </label>
-          <Input
-            id="solana-memo"
-            value={memo}
-            onChange={(event) => setMemo(event.target.value)}
-            placeholder="Enter the memo text to attach to your transaction"
-            disabled={transactionState === "sending"}
-          />
-        </div>
-        <div className="space-y-1 text-sm text-muted-foreground">
-          <p>Cluster: {client.urlOrMoniker.toString()}</p>
-          <p>
-            Wallet status: {isConnected ? "Connected" : "Not connected"}
-            {isConnected && address ? <span className="ml-1 font-mono text-xs">{address}</span> : null}
-          </p>
-        </div>
-        {connectError ? <p className="text-sm text-destructive">{connectError}</p> : null}
-        {transactionError ? <p className="text-sm text-destructive">{transactionError}</p> : null}
-      </CardContent>
-      <CardFooter className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center">
         <Button
           type="button"
           variant={isConnected ? "outline" : "default"}
-          className="flex-1 gap-2"
+          className="w-full gap-2"
           disabled={isConnecting}
-          onClick={handleConnect}
+          onClick={handleClick}
         >
           {isConnecting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Wallet className="h-4 w-4" />}
-          {isConnected ? "Reconnect Wallet" : "Connect Solana Wallet"}
+          {isConnected ? "Disconnect Wallet" : "Connect Solana Wallet"}
         </Button>
-        <Button type="button" className="flex-1 gap-2" disabled={isSendDisabled} onClick={handleSendTransaction}>
-          {transactionState === "sending" ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />}
-          {transactionState === "sent" ? "Transaction Sent" : "Send Memo"}
-        </Button>
-      </CardFooter>
-      {signature ? (
-        <div className="border-t px-6 py-4 text-sm">
-          <p className="font-medium text-foreground">Latest transaction</p>
-          <p className="font-mono text-xs break-all text-muted-foreground">{signature}</p>
-          {explorerUrl ? (
-            <a
-              className="mt-2 inline-flex items-center gap-1 text-primary hover:underline"
-              href={explorerUrl}
-              target="_blank"
-              rel="noreferrer"
-            >
-              View in Solana Explorer <ExternalLink className="h-3 w-3" />
-            </a>
+        <div className="space-y-1 text-xs text-muted-foreground">
+          <p className="font-medium text-foreground">Status: {isConnected ? "Connected" : "Not connected"}</p>
+          {isConnected && address ? (
+            <p className="break-all font-mono text-[11px]">{address}</p>
           ) : null}
+          {connectError ? <p className="text-destructive">{connectError}</p> : null}
         </div>
-      ) : null}
+      </CardContent>
     </Card>
   );
 }

--- a/src/lib/solana/wallet-context.tsx
+++ b/src/lib/solana/wallet-context.tsx
@@ -1,0 +1,113 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+import type { SolanaWindowProvider } from "@/types/solana";
+
+interface SolanaWalletContextValue {
+  provider: SolanaWindowProvider | null;
+  address: string | null;
+  isConnecting: boolean;
+  connectError: string | null;
+  connect: () => Promise<void>;
+  disconnect: () => Promise<void>;
+  signTransaction: SolanaWindowProvider["signTransaction"] | null;
+}
+
+const SolanaWalletContext = createContext<SolanaWalletContextValue | undefined>(undefined);
+
+export function SolanaWalletProvider({ children }: { children: ReactNode }) {
+  const [provider, setProvider] = useState<SolanaWindowProvider | null>(null);
+  const [address, setAddress] = useState<string | null>(null);
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [connectError, setConnectError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    setProvider(window.solana ?? null);
+  }, []);
+
+  useEffect(() => {
+    if (!provider?.on) return;
+
+    const handleDisconnect = () => {
+      setAddress(null);
+    };
+
+    provider.on("disconnect", handleDisconnect);
+    return () => {
+      provider.off?.("disconnect", handleDisconnect);
+    };
+  }, [provider]);
+
+  const connect = useCallback(async () => {
+    setConnectError(null);
+    if (!provider) {
+      setConnectError(
+        "No Solana wallet detected. Install Phantom or another Wallet Standard provider.",
+      );
+      return;
+    }
+
+    setIsConnecting(true);
+    try {
+      const result = await provider.connect({ onlyIfTrusted: false });
+      setAddress(result.publicKey.toBase58());
+    } catch (error) {
+      if (error instanceof Error) {
+        setConnectError(error.message);
+      } else {
+        setConnectError("Unable to connect to the Solana wallet.");
+      }
+    } finally {
+      setIsConnecting(false);
+    }
+  }, [provider]);
+
+  const disconnect = useCallback(async () => {
+    setConnectError(null);
+    if (!provider) return;
+
+    try {
+      await provider.disconnect?.();
+    } catch (error) {
+      console.warn("Failed to disconnect Solana wallet.", error);
+    } finally {
+      setAddress(null);
+    }
+  }, [provider]);
+
+  const signTransaction = useMemo(() => {
+    if (!provider?.signTransaction) return null;
+    return provider.signTransaction.bind(provider);
+  }, [provider]);
+
+  const value = useMemo(
+    () => ({
+      provider,
+      address,
+      isConnecting,
+      connectError,
+      connect,
+      disconnect,
+      signTransaction,
+    }),
+    [provider, address, isConnecting, connectError, connect, disconnect, signTransaction],
+  );
+
+  return <SolanaWalletContext.Provider value={value}>{children}</SolanaWalletContext.Provider>;
+}
+
+export function useSolanaWallet() {
+  const context = useContext(SolanaWalletContext);
+  if (!context) {
+    throw new Error("useSolanaWallet must be used within a SolanaWalletProvider");
+  }
+  return context;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,7 @@ import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./index.css";
 import { wagmiConfig } from "@/lib/wagmi";
+import { SolanaWalletProvider } from "@/lib/solana/wallet-context";
 
 const queryClient = new QueryClient();
 
@@ -16,7 +17,9 @@ createRoot(document.getElementById("root")!).render(
     <WagmiProvider config={wagmiConfig}>
       <QueryClientProvider client={queryClient}>
         <BrowserRouter>
-          <App />
+          <SolanaWalletProvider>
+            <App />
+          </SolanaWalletProvider>
         </BrowserRouter>
       </QueryClientProvider>
     </WagmiProvider>


### PR DESCRIPTION
## Summary
- add a shared Solana wallet context and simplify the wallet card to a connect/disconnect button
- trigger memo signing from the connected wallet whenever a document upload completes and surface signing status in the upload list
- show a new "My Document" card with the latest document timestamp, checksum, and transaction hash

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e67479e3fc8325be7a39c7651debf6