### PR TITLE
Fix wallet gating on uploads and decode signed memo transactions

### DIFF
--- a/src/components/file-upload.tsx
+++ b/src/components/file-upload.tsx
@@ -255,6 +255,11 @@ export function FileUpload({ onDocumentChange }: FileUploadProps) {
         { notify: false },
       );
 
+      if (!wallet) {
+        finalizeWithError("Please connect your wallet.");
+        return;
+      }
+
       let fileBuffer: ArrayBuffer;
       try {
         fileBuffer = await file.arrayBuffer();
@@ -281,11 +286,6 @@ export function FileUpload({ onDocumentChange }: FileUploadProps) {
       }
 
       const attemptTransactionSignature = async () => {
-        if (!wallet) {
-          applyUpdates({}, { notify: true });
-          return;
-        }
-
         applyUpdates(
           {
             transactionStatus: "pending",


### PR DESCRIPTION
## Summary
- require a connected wallet before starting PDF conversion so users see a clear error if they upload while disconnected
- adapt Solana memo transaction signing to use wallet-serializable transactions and decode the signed payload before submission

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6782404948325b1c560c9f8b55533